### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
   build:
     name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/zwfm-metadata/security/code-scanning/2](https://github.com/oszuidwest/zwfm-metadata/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `build` job in the workflow file. This block should explicitly set the permissions required for the job, which in this case is `contents: read`. This ensures that the `GITHUB_TOKEN` used by the job has only the minimal permissions necessary to complete its tasks.

**Steps to implement the fix:**
1. Add a `permissions` block under the `build` job definition.
2. Set the `contents` permission to `read`, as the job only needs to read repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
