### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,4 +1,6 @@
 name: Lint Go code
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/zwfm-metadata/security/code-scanning/1](https://github.com/oszuidwest/zwfm-metadata/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the workflow's operations. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
