### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ['main']
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '1.24'
 


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/zwfm-metadata/security/code-scanning/3](https://github.com/oszuidwest/zwfm-metadata/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only performs read operations (e.g., downloading dependencies, running tests, and checking formatting), it only requires `contents: read` permissions. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
