### PR TITLE
fix: correct DLS Plus tag length calculation for UTF-8 characters

### DIFF
--- a/outputs/dlsplus.go
+++ b/outputs/dlsplus.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"unicode/utf8"
 	"zwfm-metadata/config"
 	"zwfm-metadata/core"
 	"zwfm-metadata/utils"
@@ -102,7 +103,7 @@ func (o *DLSPlusOutput) addDLSPlusTags(content *strings.Builder, formattedText s
 	// Add artist tag if artist exists and can be found in formatted text
 	if metadata.Artist != "" {
 		if pos := strings.Index(formattedText, metadata.Artist); pos >= 0 {
-			length := len(metadata.Artist) - 1
+			length := utf8.RuneCountInString(metadata.Artist) - 1
 			if length >= 0 {
 				fmt.Fprintf(content, "DL_PLUS_TAG=%d %d %d\n", dlsPlusTypeArtist, pos, length)
 			}
@@ -112,7 +113,7 @@ func (o *DLSPlusOutput) addDLSPlusTags(content *strings.Builder, formattedText s
 	// Add title tag if title exists and can be found in formatted text
 	if metadata.Title != "" {
 		if pos := strings.Index(formattedText, metadata.Title); pos >= 0 {
-			length := len(metadata.Title) - 1
+			length := utf8.RuneCountInString(metadata.Title) - 1
 			if length >= 0 {
 				fmt.Fprintf(content, "DL_PLUS_TAG=%d %d %d\n", dlsPlusTypeTitle, pos, length)
 			}


### PR DESCRIPTION
## Problem

DLS Plus tag length was calculated using `len()` which counts **bytes**, not **characters**. This caused incorrect tag positions when metadata contained multi-byte UTF-8 characters.

### Example Bug (from #33)

With metadata: `Tiësto - Drifting`

- Artist: `Tiësto` = 6 characters, but 7 bytes (ë is 2 bytes in UTF-8)
- Using `len("Tiësto") - 1` gave length **6** (incorrect)
- Should be `6 characters - 1 = 5` (correct)
- This shifted the title tag position by 1, causing "**D**rifting" to display as "**rifting**"

## Solution

Changed from `len()` to `utf8.RuneCountInString()` to correctly count characters instead of bytes.

**Before:**
```go
length := len(metadata.Artist) - 1  // Counts bytes
```

**After:**
```go
length := utf8.RuneCountInString(metadata.Artist) - 1  // Counts characters
```

## Testing

This fix ensures proper DLS Plus tag positioning for all UTF-8 text, including:
- Accented characters (ë, é, ñ, etc.)
- Non-Latin scripts
- Any multi-byte UTF-8 characters

Fixes #33