### PR TITLE
fix(dlplus): use rune positions instead of byte positions for DL Plus tags

### DIFF
--- a/outputs/dlplus.go
+++ b/outputs/dlplus.go
@@ -102,20 +102,24 @@ func (o *DLPlusOutput) buildDLPlusContent(formattedText string, metadata *core.M
 func (o *DLPlusOutput) addDLPlusTags(content *strings.Builder, formattedText string, metadata *core.Metadata) {
 	// Add artist tag if artist exists and can be found in formatted text
 	if metadata.Artist != "" {
-		if pos := strings.Index(formattedText, metadata.Artist); pos >= 0 {
+		if bytePos := strings.Index(formattedText, metadata.Artist); bytePos >= 0 {
+			// Convert byte position to rune position for DL Plus
+			runePos := utf8.RuneCountInString(formattedText[:bytePos])
 			length := utf8.RuneCountInString(metadata.Artist) - 1
 			if length >= 0 {
-				fmt.Fprintf(content, "DL_PLUS_TAG=%d %d %d\n", dlPlusTypeArtist, pos, length)
+				fmt.Fprintf(content, "DL_PLUS_TAG=%d %d %d\n", dlPlusTypeArtist, runePos, length)
 			}
 		}
 	}
 
 	// Add title tag if title exists and can be found in formatted text
 	if metadata.Title != "" {
-		if pos := strings.Index(formattedText, metadata.Title); pos >= 0 {
+		if bytePos := strings.Index(formattedText, metadata.Title); bytePos >= 0 {
+			// Convert byte position to rune position for DL Plus
+			runePos := utf8.RuneCountInString(formattedText[:bytePos])
 			length := utf8.RuneCountInString(metadata.Title) - 1
 			if length >= 0 {
-				fmt.Fprintf(content, "DL_PLUS_TAG=%d %d %d\n", dlPlusTypeTitle, pos, length)
+				fmt.Fprintf(content, "DL_PLUS_TAG=%d %d %d\n", dlPlusTypeTitle, runePos, length)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Fix incorrect DL Plus tag positions when artist/title contain multi-byte UTF-8 characters
- Convert byte positions from `strings.Index()` to rune positions using `utf8.RuneCountInString()`

## Problem

When the artist name contains multi-byte UTF-8 characters (e.g., "Tiësto"), the title was truncated on DAB receivers. "Hot In It" displayed as "ot In It".

**Before:** `DL_PLUS_TAG=1 23 8` (byte position - wrong)
**After:** `DL_PLUS_TAG=1 22 8` (rune position - correct)

## Test plan

- [x] Tested with "Tiësto & Charli XCX - Hot In It" (special char in artist)
- [x] Tested with "BLØF & Renée - Hier Kom De Zon" (multiple special chars)
- [x] Tested with "Coldplay - Café Belgique" (special char in title)
- [x] Tested with "Daft Punk - Get Lucky" (ASCII only - regression test)
- [x] Ran `go fmt`, `go vet`, `golangci-lint` - all pass

Fixes #53