### PR TITLE
chore: add documentation and security linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,21 @@ version: "2"
 
 linters:
   enable:
+    # Existing
     - gocritic
     - gocyclo
+    # Doc/Comment
+    - godot
+    - godoclint
+    - dupword
+    - misspell
+    # Code quality
+    - errorlint
+    - gosec
+    - nilerr
+    - unparam
+    - unconvert
+    - bodyclose
   settings:
     gocritic:
       enabled-tags:
@@ -12,3 +25,5 @@ linters:
         - performance
     gocyclo:
       min-complexity: 20
+    godot:
+      scope: toplevel

--- a/formatters/rds.go
+++ b/formatters/rds.go
@@ -15,7 +15,7 @@ import (
 
 const maxRDSLength = 64
 
-// Common patterns compiled once for reuse
+// Common patterns compiled once for reuse.
 var (
 	parenRegex    = regexp.MustCompile(`\s*\([^)]*\)`)
 	bracketRegex  = regexp.MustCompile(`\s*\[[^\]]*\]`)

--- a/utils/version.go
+++ b/utils/version.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// Build information (set via ldflags during build)
+// Build information (set via ldflags during build).
 var (
 	Version   = "dev"
 	Commit    = "unknown"

--- a/web/dashboard.go
+++ b/web/dashboard.go
@@ -1,4 +1,3 @@
-// Package web provides the HTTP server and dashboard for the metadata router.
 package web
 
 // dashboardHTML returns the HTML for the dashboard.

--- a/web/icons.go
+++ b/web/icons.go
@@ -79,9 +79,9 @@ func generateFaviconICOFromSVG(svg string) ([]byte, error) {
 		buf.Write([]byte{0x01, 0x00})
 		buf.Write([]byte{0x20, 0x00})
 
-		length := uint32(len(layer.data))
+		length := uint32(len(layer.data)) //nolint:gosec // PNG layer data is always small (< 10KB)
 		buf.Write([]byte{byte(length), byte(length >> 8), byte(length >> 16), byte(length >> 24)})
-		offset := uint32(dataOffset)
+		offset := uint32(dataOffset) //nolint:gosec // ICO header offset is always small (< 100KB)
 		buf.Write([]byte{byte(offset), byte(offset >> 8), byte(offset >> 16), byte(offset >> 24)})
 
 		dataOffset += len(layer.data)


### PR DESCRIPTION
## Summary
- Enable additional golangci-lint checks: godot, godoclint, dupword, misspell, errorlint, gosec, nilerr, unparam, unconvert, bodyclose
- Fix all issues found by new linters:
  - Add periods to top-level comments (godot)
  - Remove duplicate package comment in web/dashboard.go (godoclint)
  - Add nolint directives for safe integer conversions in web/icons.go (gosec)

## Test plan
- [x] `golangci-lint run --timeout=5m` passes with 0 issues
- [x] `go build` succeeds
- [x] `go vet ./...` passes