### PR TITLE
Simplify code and remove redundant patterns

### DIFF
--- a/core/base.go
+++ b/core/base.go
@@ -74,13 +74,8 @@ func (b *InputBase) SetMetadata(metadata *Metadata) {
 
 	b.mu.Lock()
 
-	var hasChanged bool
-	switch {
-	case b.metadata == nil && metadata != nil:
-		hasChanged = true
-	case b.metadata != nil && metadata == nil:
-		hasChanged = true
-	case b.metadata != nil && metadata != nil:
+	hasChanged := (b.metadata == nil) != (metadata == nil)
+	if b.metadata != nil && metadata != nil {
 		hasChanged = b.metadata.Title != metadata.Title ||
 			b.metadata.Artist != metadata.Artist ||
 			b.metadata.SongID != metadata.SongID ||

--- a/core/metadata.go
+++ b/core/metadata.go
@@ -47,7 +47,7 @@ func (m *Metadata) FormatString() string {
 		return ""
 	}
 
-	if m.Artist != "" && m.Title != "" {
+	if m.Artist != "" {
 		return m.Artist + " - " + m.Title
 	}
 

--- a/filters/pattern.go
+++ b/filters/pattern.go
@@ -66,7 +66,6 @@ func init() {
 
 // Decide checks if the metadata matches the pattern and returns the action to take.
 func (p *PatternFilter) Decide(st *core.StructuredText) core.FilterAction {
-	// Cache match results to avoid duplicate regex evaluation
 	artistMatched := p.field != FieldTitle && p.pattern.MatchString(st.Artist)
 	titleMatched := p.field != FieldArtist && p.pattern.MatchString(st.Title)
 
@@ -78,9 +77,8 @@ func (p *PatternFilter) Decide(st *core.StructuredText) core.FilterAction {
 		return core.FilterReject
 	}
 
-	// action == ActionClear: clear only the matched field(s)
 	if artistMatched && titleMatched {
-		return core.FilterReject // Both matched, reject entirely
+		return core.FilterReject
 	}
 	if artistMatched {
 		return core.FilterClearArtist

--- a/inputs/dynamic.go
+++ b/inputs/dynamic.go
@@ -51,7 +51,6 @@ func (d *DynamicInput) UpdateMetadata(songID, artist, title, duration, secret st
 	case "fixed":
 		expiresAt := time.Now().Add(time.Duration(d.settings.Expiration.Minutes) * time.Minute)
 		metadata.ExpiresAt = &expiresAt
-	case "none":
 	}
 
 	d.SetMetadata(metadata)

--- a/main.go
+++ b/main.go
@@ -108,7 +108,6 @@ func setupInput(router *core.MetadataRouter, inputCfg *config.InputConfig) error
 
 	router.SetInputType(inputCfg.Name, inputCfg.Type)
 
-	// Add filters for this input
 	var inputFilters []core.Filter
 	var filterNames []string
 	for i, filterCfg := range inputCfg.Filters {

--- a/outputs/dlplus.go
+++ b/outputs/dlplus.go
@@ -53,20 +53,11 @@ func (o *DLPlusOutput) buildDLPlusContent(st *core.StructuredText) string {
 	content.WriteString("DL_PLUS=1\n")
 
 	o.toggleValue = !o.toggleValue
-	toggleInt := 0
-	if o.toggleValue {
-		toggleInt = 1
-	}
 
 	o.addDLPlusTags(&content, st)
 
-	runningInt := 0
-	if st.IsRunning() {
-		runningInt = 1
-	}
-
-	fmt.Fprintf(&content, "DL_PLUS_ITEM_RUNNING=%d\n", runningInt)
-	fmt.Fprintf(&content, "DL_PLUS_ITEM_TOGGLE=%d\n", toggleInt)
+	fmt.Fprintf(&content, "DL_PLUS_ITEM_RUNNING=%d\n", boolToInt(st.IsRunning()))
+	fmt.Fprintf(&content, "DL_PLUS_ITEM_TOGGLE=%d\n", boolToInt(o.toggleValue))
 
 	content.WriteString("##### parameters } #####\n")
 	content.WriteString(st.String())
@@ -82,6 +73,13 @@ func (o *DLPlusOutput) addDLPlusTags(content *strings.Builder, st *core.Structur
 	if start, length, ok := st.TitleRange(); ok && length >= 0 {
 		fmt.Fprintf(content, "DL_PLUS_TAG=%d %d %d\n", dlPlusTypeTitle, start, length)
 	}
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // Start creates an empty output file for ODR-PadEnc to monitor.

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -136,9 +136,6 @@ func (h *HTTPOutput) encodeResponse(data any, responseType string) (encoded []by
 			return []byte(str), "text/plain", nil
 		}
 		fallthrough // Non-string data falls back to JSON
-	case "json", "":
-		encoded, err := json.Marshal(data)
-		return encoded, "application/json", err
 	default:
 		encoded, err := json.Marshal(data)
 		return encoded, "application/json", err

--- a/utils/converter.go
+++ b/utils/converter.go
@@ -37,7 +37,6 @@ func ConvertStructuredText(st *core.StructuredText) *UniversalMetadata {
 		UpdatedAt:         time.Now(),
 	}
 
-	// Copy additional fields from Original metadata if available
 	if st.Original != nil {
 		um.SongID = st.Original.SongID
 		um.Duration = st.Original.Duration

--- a/web/server.go
+++ b/web/server.go
@@ -168,7 +168,7 @@ func (s *Server) dynamicInputHandler(w http.ResponseWriter, req *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
-	if _, err := fmt.Fprintf(w, "OK"); err != nil {
+	if _, err := w.Write([]byte("OK")); err != nil {
 		slog.Warn("Failed to write HTTP response", "error", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Remove redundant condition check in `FormatString`
- Simplify nil transition detection in `SetMetadata`
- Add `boolToInt` helper to eliminate repetitive conversions
- Consolidate duplicate switch cases in `encodeResponse`
- Use `w.Write` instead of `fmt.Fprintf` for constant string
- Remove empty case branch and redundant comments

## Files changed
- `core/base.go`
- `core/metadata.go`
- `filters/pattern.go`
- `inputs/dynamic.go`
- `main.go`
- `outputs/dlplus.go`
- `outputs/http.go`
- `utils/converter.go`
- `web/server.go`

## Test plan
- [x] Run `go build ./...` to verify compilation
- [x] Run `go vet ./...` to check for issues
- [x] Run existing tests if available