### PR TITLE
chore: bump Go from 1.26.0 to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module zwfm-metadata
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Summary
- Bump Go version from 1.26.0 to 1.26.1 in go.mod