### PR TITLE
Add configurable expiration rounding for dynamic inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ HTTP API for live updates
 - `secret` (optional) - Authentication secret for API calls
 - `expiration.type` - `"dynamic"` (expires based on song duration), `"fixed"` (expires after a set number of minutes), or `"none"` (never expires)
 - `expiration.minutes` (required if type=fixed, optional for type=dynamic) - Number of minutes until expiration. When `type` is `"dynamic"`, this serves as a fallback when the duration parameter is missing or invalid
-- `expiration.roundUpMinutes` (optional, default: true) - When `true` (or omitted), dynamic expiration rounds up to full minutes (e.g., 3:30 → 4 minutes). This prevents metadata "flapping" when short segments like talk or jingles follow a song. Set to `false` to use exact second-based expiration
+- `expiration.roundUpMinutes` (optional, default: true, only for type=dynamic) - When `true` (or omitted), dynamic expiration rounds up to full minutes (e.g., 3:30 → 4 minutes). This prevents metadata "flapping" when short segments like talk or jingles follow a song. Set to `false` to use exact second-based expiration
 
 #### API Usage
 ```bash

--- a/config-example.json
+++ b/config-example.json
@@ -26,7 +26,8 @@
       "settings": {
         "secret": "supersecret123",
         "expiration": {
-          "type": "dynamic"
+          "type": "dynamic",
+          "roundUpMinutes": true
         }
       }
     },

--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ type DynamicInputConfig struct {
 	Expiration struct {
 		Type           string `json:"type"`                     // "dynamic", "fixed", "none"
 		Minutes        int    `json:"minutes,omitempty"`        // Fallback minutes for dynamic, or fixed duration
-		RoundUpMinutes *bool  `json:"roundUpMinutes,omitempty"` // Round up expiration to full minutes (default: true)
+		RoundUpMinutes *bool  `json:"roundUpMinutes,omitempty"` // Round up dynamic expiration to full minutes (default: true)
 	} `json:"expiration"`
 }
 

--- a/inputs/dynamic.go
+++ b/inputs/dynamic.go
@@ -20,6 +20,10 @@ type DynamicInput struct {
 
 // NewDynamicInput initializes an HTTP API-driven input with the given settings.
 func NewDynamicInput(name string, settings config.DynamicInputConfig) *DynamicInput {
+	if settings.Expiration.RoundUpMinutes != nil && settings.Expiration.Type != "dynamic" {
+		slog.Warn("roundUpMinutes is only used with expiration type \"dynamic\" and will be ignored", "input", name, "type", settings.Expiration.Type)
+	}
+
 	return &DynamicInput{
 		InputBase:      core.NewInputBase(name),
 		settings:       settings,


### PR DESCRIPTION
## Summary

- Adds `roundUpMinutes` option to dynamic input expiration config
- Default behavior unchanged: durations are rounded up to full minutes (prevents metadata flapping during short talk/jingle segments)
- Setting `"roundUpMinutes": false` enables exact second-based expiration for use cases that need precise timing

### Config example

```json
{
  "expiration": {
    "type": "dynamic",
    "roundUpMinutes": false
  }
}
```

Closes #89

## Test plan

- [x] Verify default behavior (no `roundUpMinutes` set) still rounds up to minutes
- [x] Verify `"roundUpMinutes": true` rounds up to minutes
- [x] Verify `"roundUpMinutes": false` uses exact seconds (e.g., 3:30 → 210 seconds, not 4 minutes)
- [x] Verify existing configs without the new field work without changes