### PR TITLE
fix: concurrent write panic in WebSocket hub

### DIFF
--- a/utils/websocket_hub.go
+++ b/utils/websocket_hub.go
@@ -18,33 +18,8 @@ type WebSocketConn struct {
 
 type hubClient struct {
 	conn    *websocket.Conn
+	wsConn  *WebSocketConn
 	writeMu sync.Mutex
-}
-
-func (c *hubClient) writeJSON(data any, timeout time.Duration) error {
-	c.writeMu.Lock()
-	defer c.writeMu.Unlock()
-
-	if err := c.conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
-		return err
-	}
-	if err := c.conn.WriteJSON(data); err != nil {
-		return err
-	}
-	return c.conn.SetWriteDeadline(time.Time{})
-}
-
-func (c *hubClient) writeMessage(messageType int, data []byte, timeout time.Duration) error {
-	c.writeMu.Lock()
-	defer c.writeMu.Unlock()
-
-	if err := c.conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
-		return err
-	}
-	if err := c.conn.WriteMessage(messageType, data); err != nil {
-		return err
-	}
-	return c.conn.SetWriteDeadline(time.Time{})
 }
 
 // WebSocketHub manages WebSocket connections and broadcasting.
@@ -86,6 +61,64 @@ func (h *WebSocketHub) SetOnDisconnect(fn func(*WebSocketConn)) {
 	h.onDisconnect = fn
 }
 
+func (h *WebSocketHub) writeClient(client *hubClient, operation string, write func() error) error {
+	client.writeMu.Lock()
+	defer client.writeMu.Unlock()
+
+	if err := client.conn.SetWriteDeadline(time.Now().Add(h.writeTimeout)); err != nil {
+		slog.Warn("Failed to set WebSocket write deadline", "hub", h.name, "operation", operation, "error", err)
+	}
+	if err := write(); err != nil {
+		return err
+	}
+	if err := client.conn.SetWriteDeadline(time.Time{}); err != nil {
+		slog.Warn("Failed to clear WebSocket write deadline", "hub", h.name, "operation", operation, "error", err)
+	}
+	return nil
+}
+
+func (h *WebSocketHub) writeClientJSON(client *hubClient, operation string, data any) error {
+	return h.writeClient(client, operation, func() error {
+		return client.conn.WriteJSON(data)
+	})
+}
+
+func (h *WebSocketHub) writeClientMessage(client *hubClient, operation string, messageType int, data []byte) error {
+	return h.writeClient(client, operation, func() error {
+		return client.conn.WriteMessage(messageType, data)
+	})
+}
+
+func (h *WebSocketHub) removeClient(client *hubClient) (int, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, exists := h.clients[client.conn]; !exists {
+		return len(h.clients), false
+	}
+
+	delete(h.clients, client.conn)
+	return len(h.clients), true
+}
+
+func (h *WebSocketHub) disconnectClient(client *hubClient) int {
+	clientCount, removed := h.removeClient(client)
+	if !removed {
+		return clientCount
+	}
+
+	if err := client.conn.Close(); err != nil {
+		slog.Warn("Failed to close WebSocket connection", "hub", h.name, "error", err)
+	}
+
+	if h.onDisconnect != nil {
+		h.onDisconnect(client.wsConn)
+	}
+
+	slog.Debug("WebSocket client disconnected", "hub", h.name, "clients", clientCount)
+	return clientCount
+}
+
 // HandleConnection handles a new WebSocket connection.
 func (h *WebSocketHub) HandleConnection(w http.ResponseWriter, r *http.Request) {
 	conn, err := h.upgrader.Upgrade(w, r, nil)
@@ -94,7 +127,8 @@ func (h *WebSocketHub) HandleConnection(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	client := &hubClient{conn: conn}
+	wsConn := &WebSocketConn{Conn: conn}
+	client := &hubClient{conn: conn, wsConn: wsConn}
 
 	h.mu.Lock()
 	h.clients[conn] = client
@@ -103,12 +137,12 @@ func (h *WebSocketHub) HandleConnection(w http.ResponseWriter, r *http.Request) 
 
 	slog.Debug("WebSocket client connected", "hub", h.name, "clients", clientCount)
 
-	wsConn := &WebSocketConn{Conn: conn}
-
 	if h.onConnect != nil {
 		if data := h.onConnect(wsConn); data != nil {
-			if err := client.writeJSON(data, h.writeTimeout); err != nil {
-				slog.Debug("Failed to send initial data", "hub", h.name, "error", err)
+			if err := h.writeClientJSON(client, "on_connect", data); err != nil {
+				slog.Warn("Failed to send initial WebSocket data", "hub", h.name, "error", err)
+				h.disconnectClient(client)
+				return
 			}
 		}
 	}
@@ -133,7 +167,8 @@ func (h *WebSocketHub) HandleConnection(w http.ResponseWriter, r *http.Request) 
 		for {
 			select {
 			case <-ticker.C:
-				if err := client.writeMessage(websocket.PingMessage, nil, h.writeTimeout); err != nil {
+				if err := h.writeClientMessage(client, "ping", websocket.PingMessage, nil); err != nil {
+					slog.Debug("WebSocket ping failed", "hub", h.name, "error", err)
 					return
 				}
 			case <-done:
@@ -149,20 +184,7 @@ func (h *WebSocketHub) HandleConnection(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	if err := conn.Close(); err != nil {
-		slog.Warn("Failed to close connection", "error", err)
-	}
-
-	h.mu.Lock()
-	delete(h.clients, conn)
-	clientCount = len(h.clients)
-	h.mu.Unlock()
-
-	if h.onDisconnect != nil {
-		h.onDisconnect(wsConn)
-	}
-
-	slog.Debug("WebSocket client disconnected", "hub", h.name, "clients", clientCount)
+	h.disconnectClient(client)
 }
 
 // Broadcast sends data to all connected clients.
@@ -172,13 +194,9 @@ func (h *WebSocketHub) Broadcast(data any) {
 	h.mu.RUnlock()
 
 	for _, client := range clients {
-		if err := client.writeJSON(data, h.writeTimeout); err != nil {
-			h.mu.Lock()
-			delete(h.clients, client.conn)
-			h.mu.Unlock()
-			if err := client.conn.Close(); err != nil {
-				slog.Warn("Failed to close client connection", "error", err)
-			}
+		if err := h.writeClientJSON(client, "broadcast", data); err != nil {
+			slog.Warn("Failed to broadcast WebSocket message", "hub", h.name, "error", err)
+			h.disconnectClient(client)
 		}
 	}
 }

--- a/utils/websocket_hub_test.go
+++ b/utils/websocket_hub_test.go
@@ -1,9 +1,9 @@
 package utils
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -13,58 +13,308 @@ import (
 )
 
 func TestWebSocketHubBroadcastSerializesConcurrentWriters(t *testing.T) {
-	t.Parallel()
-
-	runtime.GOMAXPROCS(8)
-
 	hub := NewWebSocketHub("test")
-	server := httptest.NewServer(http.HandlerFunc(hub.HandleConnection))
+	conn, server := dialTestWebSocket(t, hub)
 	defer server.Close()
+	defer conn.Close() //nolint:errcheck // Best-effort cleanup
 
-	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
-	if err != nil {
-		t.Fatalf("Dial() error = %v", err)
-	}
-	defer resp.Body.Close() //nolint:errcheck // Best-effort cleanup
-	defer conn.Close()      //nolint:errcheck // Best-effort cleanup
+	messages := startMessageReader(conn)
+	waitForClientCount(t, hub, 1, time.Second)
 
-	done := make(chan struct{})
-	defer close(done)
+	const rounds = 25
+	const writersPerRound = 8
 
-	go func() {
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				if _, _, err := conn.ReadMessage(); err != nil {
-					return
-				}
-			}
-		}
-	}()
+	expectedIDs := make(map[string]struct{}, rounds*writersPerRound)
 
-	time.Sleep(100 * time.Millisecond)
-
-	for round := 0; round < 100; round++ {
+	for round := 0; round < rounds; round++ {
 		start := make(chan struct{})
 		var wg sync.WaitGroup
 
-		for writer := 0; writer < 8; writer++ {
+		for writer := 0; writer < writersPerRound; writer++ {
+			id := fmt.Sprintf("round-%d-writer-%d", round, writer)
+			expectedIDs[id] = struct{}{}
+
 			wg.Add(1)
-			go func(id int) {
+			go func(messageID string) {
 				defer wg.Done()
 				<-start
 				hub.Broadcast(map[string]any{
-					"round":  round,
-					"writer": id,
-					"text":   "test-message",
+					"id":   messageID,
+					"kind": "broadcast",
 				})
-			}(writer)
+			}(id)
 		}
 
 		close(start)
 		wg.Wait()
 	}
+
+	received := waitForMessages(t, messages, len(expectedIDs), 5*time.Second)
+	assertMessageIDs(t, received, expectedIDs)
+
+	if got := hub.ClientCount(); got != 1 {
+		t.Fatalf("ClientCount() = %d, want 1", got)
+	}
+}
+
+func TestWebSocketHubBroadcastSerializesWithPingWriter(t *testing.T) {
+	hub := NewWebSocketHub("test")
+	hub.pingInterval = 5 * time.Millisecond
+
+	conn, server := dialTestWebSocket(t, hub)
+	defer server.Close()
+	defer conn.Close() //nolint:errcheck // Best-effort cleanup
+
+	messages := startMessageReader(conn)
+	waitForClientCount(t, hub, 1, time.Second)
+
+	const broadcasts = 30
+	expectedIDs := make(map[string]struct{}, broadcasts)
+
+	for i := 0; i < broadcasts; i++ {
+		id := fmt.Sprintf("ping-race-%d", i)
+		expectedIDs[id] = struct{}{}
+
+		hub.Broadcast(map[string]any{
+			"id":   id,
+			"kind": "broadcast",
+		})
+
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	received := waitForMessages(t, messages, len(expectedIDs), 5*time.Second)
+	assertMessageIDs(t, received, expectedIDs)
+
+	if got := hub.ClientCount(); got != 1 {
+		t.Fatalf("ClientCount() = %d, want 1", got)
+	}
+}
+
+func TestWebSocketHubBroadcastSerializesWithOnConnectWriter(t *testing.T) {
+	hub := NewWebSocketHub("test")
+
+	onConnectStarted := make(chan struct{})
+	releaseOnConnect := make(chan struct{})
+
+	hub.SetOnConnect(func(*WebSocketConn) any {
+		close(onConnectStarted)
+		<-releaseOnConnect
+		return map[string]any{
+			"id":   "initial-state",
+			"kind": "initial",
+		}
+	})
+
+	conn, server := dialTestWebSocket(t, hub)
+	defer server.Close()
+	defer conn.Close() //nolint:errcheck // Best-effort cleanup
+
+	messages := startMessageReader(conn)
+	waitForClientCount(t, hub, 1, time.Second)
+
+	select {
+	case <-onConnectStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for onConnect callback")
+	}
+
+	const broadcasts = 20
+	expectedIDs := make(map[string]struct{}, broadcasts)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < broadcasts; i++ {
+		id := fmt.Sprintf("on-connect-race-%d", i)
+		expectedIDs[id] = struct{}{}
+
+		wg.Add(1)
+		go func(messageID string) {
+			defer wg.Done()
+			<-start
+			hub.Broadcast(map[string]any{
+				"id":   messageID,
+				"kind": "broadcast",
+			})
+		}(id)
+	}
+
+	close(start)
+	close(releaseOnConnect)
+	wg.Wait()
+
+	received := waitForMessages(t, messages, broadcasts+1, 5*time.Second)
+	assertMessageIDs(t, received, expectedIDs)
+
+	if !hasMessageKind(received, "initial") {
+		t.Fatal("expected initial onConnect message")
+	}
+
+	if got := hub.ClientCount(); got != 1 {
+		t.Fatalf("ClientCount() = %d, want 1", got)
+	}
+}
+
+func TestWebSocketHubOnConnectWriteFailureRemovesClient(t *testing.T) {
+	hub := NewWebSocketHub("test")
+
+	onConnectStarted := make(chan struct{})
+	releaseOnConnect := make(chan struct{})
+	disconnected := make(chan struct{}, 1)
+
+	hub.SetOnConnect(func(*WebSocketConn) any {
+		close(onConnectStarted)
+		<-releaseOnConnect
+		return map[string]any{
+			"id":   "initial-state",
+			"kind": "initial",
+		}
+	})
+
+	hub.SetOnDisconnect(func(*WebSocketConn) {
+		select {
+		case disconnected <- struct{}{}:
+		default:
+		}
+	})
+
+	conn, server := dialTestWebSocket(t, hub)
+	defer server.Close()
+	defer conn.Close() //nolint:errcheck // Best-effort cleanup
+
+	waitForClientCount(t, hub, 1, time.Second)
+
+	select {
+	case <-onConnectStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for onConnect callback")
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	close(releaseOnConnect)
+
+	waitForClientCount(t, hub, 0, time.Second)
+
+	select {
+	case <-disconnected:
+	case <-time.After(time.Second):
+		t.Fatal("expected onDisconnect callback after failed initial write")
+	}
+}
+
+func dialTestWebSocket(t *testing.T, hub *WebSocketHub) (*websocket.Conn, *httptest.Server) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(hub.HandleConnection))
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		server.Close()
+		t.Fatalf("Dial() error = %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close() //nolint:errcheck,gosec // Best-effort cleanup
+	}
+
+	return conn, server
+}
+
+func startMessageReader(conn *websocket.Conn) <-chan map[string]any {
+	messages := make(chan map[string]any, 512)
+
+	go func() {
+		defer close(messages)
+
+		for {
+			var message map[string]any
+			if err := conn.ReadJSON(&message); err != nil {
+				return
+			}
+			messages <- message
+		}
+	}()
+
+	return messages
+}
+
+func waitForClientCount(t *testing.T, hub *WebSocketHub, want int, timeout time.Duration) { //nolint:unparam // Timeout varies by caller intent
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if got := hub.ClientCount(); got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for ClientCount() == %d, got %d", want, hub.ClientCount())
+}
+
+func waitForMessages(t *testing.T, messages <-chan map[string]any, want int, timeout time.Duration) []map[string]any {
+	t.Helper()
+
+	received := make([]map[string]any, 0, want)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for len(received) < want {
+		select {
+		case message, ok := <-messages:
+			if !ok {
+				t.Fatalf("message stream closed after %d messages, want %d", len(received), want)
+			}
+			received = append(received, message)
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %d messages, got %d", want, len(received))
+		}
+	}
+
+	return received
+}
+
+func assertMessageIDs(t *testing.T, messages []map[string]any, wantIDs map[string]struct{}) {
+	t.Helper()
+
+	receivedIDs := make(map[string]struct{}, len(messages))
+
+	for _, message := range messages {
+		kind, _ := message["kind"].(string)
+		if kind != "broadcast" {
+			continue
+		}
+
+		id, ok := message["id"].(string)
+		if !ok {
+			t.Fatalf("broadcast message missing string id: %#v", message)
+		}
+
+		receivedIDs[id] = struct{}{}
+	}
+
+	if len(receivedIDs) != len(wantIDs) {
+		t.Fatalf("received %d broadcast IDs, want %d", len(receivedIDs), len(wantIDs))
+	}
+
+	for id := range wantIDs {
+		if _, ok := receivedIDs[id]; !ok {
+			t.Fatalf("missing broadcast message id %q", id)
+		}
+	}
+}
+
+func hasMessageKind(messages []map[string]any, want string) bool {
+	for _, message := range messages {
+		kind, ok := message["kind"].(string)
+		if ok && kind == want {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
## Summary

- Adds a per-connection write mutex (`hubClient`) to serialize all write operations on each `*websocket.Conn`
- Gorilla/websocket only supports one concurrent writer per connection. Concurrent writes cause a panic (as reported in #96)
- All three write paths (initial connect data, periodic pings, broadcasts) are serialized via a unified `writeClient` method
- Centralizes disconnect logic in `removeClient`/`disconnectClient` with an exists guard to prevent double-close races
- Restores write-failure logging at Warn level for broadcast and onConnect paths
- Makes write-deadline errors non-fatal to avoid disconnecting clients after successful writes
- Removes and closes clients immediately on failed onConnect writes

## Test plan

- [x] `go test -race ./utils/` passes
- [x] `go test -race ./...` passes (no regressions)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean

### Test coverage

| Test | Scenario |
|------|----------|
| `TestWebSocketHubBroadcastSerializesConcurrentWriters` | 25 rounds x 8 concurrent writers, verifies all messages received by ID |
| `TestWebSocketHubBroadcastSerializesWithPingWriter` | Broadcasts interleaved with 5ms ping interval, verifies no race |
| `TestWebSocketHubBroadcastSerializesWithOnConnectWriter` | Concurrent broadcasts racing with onConnect initial write |
| `TestWebSocketHubOnConnectWriteFailureRemovesClient` | Failed initial write removes client and fires onDisconnect |

Closes #96