### PR TITLE
fix: log pong handler deadline failures before propagating to Gorilla

### DIFF
--- a/utils/websocket_hub.go
+++ b/utils/websocket_hub.go
@@ -214,7 +214,11 @@ func (h *WebSocketHub) readPump(client *hubClient) {
 		slog.Warn("Failed to set read deadline", "hub", h.name, "error", err)
 	}
 	client.conn.SetPongHandler(func(string) error {
-		return client.conn.SetReadDeadline(time.Now().Add(h.pongWait))
+		err := client.conn.SetReadDeadline(time.Now().Add(h.pongWait))
+		if err != nil {
+			slog.Debug("WebSocket pong deadline failed", "hub", h.name, "error", err)
+		}
+		return err
 	})
 
 	for {


### PR DESCRIPTION
## Summary
- Adds debug-level logging in the WebSocket pong handler when `SetReadDeadline` fails, before returning the error to Gorilla
- This commit was missed during the squash merge of #99

## Test plan
- [x] Verify the pong handler still returns errors correctly
- [x] Confirm debug log appears when a deadline failure occurs