### PR TITLE
fix: bump Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module zwfm-metadata
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Summary

- Bumps the Go toolchain version in `go.mod` from `1.26.1` to `1.26.2`
- Resolves `govulncheck` failures caused by known vulnerabilities in the Go standard library present in versions prior to 1.26.2

## Background

Go 1.26.2 is a patch release that addresses security vulnerabilities in the following standard library packages:

- **`crypto/x509`** — certificate parsing and validation issues
- **`crypto/tls`** — TLS handshake/protocol vulnerabilities
- **`html/template`** — template injection vulnerabilities

Without this bump, `govulncheck` flags these vulnerabilities during CI, blocking releases.

## Test plan

- [ ] Verify `go build ./...` succeeds after the version bump
- [ ] Run `govulncheck ./...` and confirm no stdlib CVEs are reported
- [ ] Confirm CI passes on this branch