### PR TITLE
style: code style fixes, MetadataRequest struct, nil guard

### DIFF
--- a/core/manager.go
+++ b/core/manager.go
@@ -441,7 +441,11 @@ func (mr *MetadataRouter) scheduleInputChangeUpdates(inputName string, metadata 
 		mr.timeline.addUpdate(&update)
 
 		if delay > 0 {
-			slog.Debug("Scheduled update for output", "output", outputName, "time", executeAt.Format("15:04:05"), "delay_seconds", int(delay.Seconds()))
+			slog.Debug("Scheduled update for output",
+				"output", outputName,
+				"time", executeAt.Format("15:04:05"),
+				"delay_seconds", int(delay.Seconds()),
+			)
 		} else {
 			slog.Debug("Scheduled immediate update for output", "output", outputName)
 		}
@@ -548,7 +552,9 @@ func (mr *MetadataRouter) currentInputNeedsFallback(outputName string) bool {
 }
 
 // scheduleFallbackUpdate schedules an expiration fallback update if the content differs from last sent.
-func (mr *MetadataRouter) scheduleFallbackUpdate(outputName string, output Output, inputName string, metadata *Metadata) {
+func (mr *MetadataRouter) scheduleFallbackUpdate(
+	outputName string, output Output, inputName string, metadata *Metadata,
+) {
 	st := mr.transformMetadataForOutput(outputName, metadata, inputName)
 	if !st.HasContent() {
 		return
@@ -572,7 +578,11 @@ func (mr *MetadataRouter) scheduleFallbackUpdate(outputName string, output Outpu
 	}
 
 	mr.timeline.addUpdate(&update)
-	slog.Debug("Scheduled expiration fallback for output", "output", outputName, "time", executeAt.Format("15:04:05"), "delay_seconds", int(delay.Seconds()))
+	slog.Debug("Scheduled expiration fallback for output",
+		"output", outputName,
+		"time", executeAt.Format("15:04:05"),
+		"delay_seconds", int(delay.Seconds()),
+	)
 }
 
 // applyFilterAction applies the action specified by a filter to a StructuredText.
@@ -641,7 +651,9 @@ func (mr *MetadataRouter) wouldFiltersReject(inputName string, metadata *Metadat
 // transformMetadataForOutput builds a StructuredText from metadata with prefix/suffix and formatters applied.
 // NOTE: This method reads inputPrefixSuffix, inputTypes, inputFilters, and outputFormatters
 // without locks. These maps are immutable after Start() - enforced by panicIfStarted in Set* methods.
-func (mr *MetadataRouter) transformMetadataForOutput(outputName string, metadata *Metadata, inputName string) *StructuredText {
+func (mr *MetadataRouter) transformMetadataForOutput(
+	outputName string, metadata *Metadata, inputName string,
+) *StructuredText {
 	if metadata == nil {
 		return nil
 	}
@@ -761,7 +773,11 @@ func (mr *MetadataRouter) executeUpdate(update *ScheduledUpdate) {
 	mr.currentInputs[update.OutputName] = inputName
 	mr.mu.Unlock()
 
-	slog.Debug("Executing update for output", "update_type", update.UpdateType, "output", update.OutputName, "text", formattedText)
+	slog.Debug("Executing update for output",
+		"update_type", update.UpdateType,
+		"output", update.OutputName,
+		"text", formattedText,
+	)
 
 	update.Output.Send(st)
 }

--- a/inputs/dynamic.go
+++ b/inputs/dynamic.go
@@ -21,7 +21,10 @@ type DynamicInput struct {
 // NewDynamicInput initializes an HTTP API-driven input with the given settings.
 func NewDynamicInput(name string, settings config.DynamicInputConfig) *DynamicInput {
 	if settings.Expiration.RoundUpMinutes != nil && settings.Expiration.Type != "dynamic" {
-		slog.Warn("roundUpMinutes is only used with expiration type \"dynamic\" and will be ignored", "input", name, "type", settings.Expiration.Type)
+		slog.Warn("roundUpMinutes is only used with expiration type \"dynamic\" and will be ignored",
+			"input", name,
+			"type", settings.Expiration.Type,
+		)
 	}
 
 	return &DynamicInput{
@@ -31,28 +34,37 @@ func NewDynamicInput(name string, settings config.DynamicInputConfig) *DynamicIn
 	}
 }
 
+// MetadataUpdate holds the fields for an incoming metadata update via the HTTP API.
+type MetadataUpdate struct {
+	SongID   string
+	Artist   string
+	Title    string
+	Duration string
+	Secret   string
+}
+
 // UpdateMetadata updates the metadata from an HTTP request.
-func (d *DynamicInput) UpdateMetadata(songID, artist, title, duration, secret string) error {
-	if d.settings.Secret != "" && secret != d.settings.Secret {
+func (d *DynamicInput) UpdateMetadata(update MetadataUpdate) error {
+	if d.settings.Secret != "" && update.Secret != d.settings.Secret {
 		return fmt.Errorf("invalid secret")
 	}
 
-	if title == "" {
+	if update.Title == "" {
 		return fmt.Errorf("title is required")
 	}
 
 	metadata := &core.Metadata{
 		Name:      d.GetName(),
-		SongID:    songID,
-		Artist:    artist,
-		Title:     title,
-		Duration:  duration,
+		SongID:    update.SongID,
+		Artist:    update.Artist,
+		Title:     update.Title,
+		Duration:  update.Duration,
 		UpdatedAt: time.Now(),
 	}
 
 	switch d.settings.Expiration.Type {
 	case "dynamic":
-		expiresAt := d.calculateDynamicExpiration(duration)
+		expiresAt := d.calculateDynamicExpiration(update.Duration)
 		metadata.ExpiresAt = &expiresAt
 	case "fixed":
 		expiresAt := time.Now().Add(time.Duration(d.settings.Expiration.Minutes) * time.Minute)
@@ -72,7 +84,10 @@ func (d *DynamicInput) calculateDynamicExpiration(duration string) time.Time {
 	}
 
 	if totalSeconds <= 0 {
-		slog.Error("Duration must be greater than 0 seconds - will expire immediately", "input", d.GetName(), "duration", duration)
+		slog.Error("Duration must be greater than 0 seconds - will expire immediately",
+			"input", d.GetName(),
+			"duration", duration,
+		)
 		return time.Now()
 	}
 
@@ -84,7 +99,13 @@ func (d *DynamicInput) calculateDynamicExpiration(duration string) time.Time {
 		expiresAt = time.Now().Add(time.Duration(totalSeconds) * time.Second)
 	}
 
-	slog.Debug("Calculated dynamic expiration", "input", d.GetName(), "duration", duration, "totalSeconds", totalSeconds, "roundUpMinutes", d.roundUpMinutes, "expiresAt", expiresAt.Format("15:04:05"))
+	slog.Debug("Calculated dynamic expiration",
+		"input", d.GetName(),
+		"duration", duration,
+		"totalSeconds", totalSeconds,
+		"roundUpMinutes", d.roundUpMinutes,
+		"expiresAt", expiresAt.Format("15:04:05"),
+	)
 
 	return expiresAt
 }
@@ -93,9 +114,17 @@ func (d *DynamicInput) calculateDynamicExpiration(duration string) time.Time {
 func (d *DynamicInput) handleUnsupportedFormat(duration string) time.Time {
 	if d.settings.Expiration.Minutes > 0 {
 		expiresAt := time.Now().Add(time.Duration(d.settings.Expiration.Minutes) * time.Minute)
-		slog.Error("Unsupported duration format - using fixed expiration", "input", d.GetName(), "duration", duration, "expected", "seconds, MM:SS, or HH:MM:SS format only")
+		slog.Error("Unsupported duration format - using fixed expiration",
+			"input", d.GetName(),
+			"duration", duration,
+			"expected", "seconds, MM:SS, or HH:MM:SS format only",
+		)
 		return expiresAt
 	}
-	slog.Error("Unsupported duration format - will expire immediately", "input", d.GetName(), "duration", duration, "expected", "seconds, MM:SS, or HH:MM:SS format only")
+	slog.Error("Unsupported duration format - will expire immediately",
+		"input", d.GetName(),
+		"duration", duration,
+		"expected", "seconds, MM:SS, or HH:MM:SS format only",
+	)
 	return time.Now()
 }

--- a/inputs/dynamic.go
+++ b/inputs/dynamic.go
@@ -44,7 +44,7 @@ type MetadataUpdate struct {
 }
 
 // UpdateMetadata updates the metadata from an HTTP request.
-func (d *DynamicInput) UpdateMetadata(update MetadataUpdate) error {
+func (d *DynamicInput) UpdateMetadata(update *MetadataUpdate) error {
 	if d.settings.Secret != "" && update.Secret != d.settings.Secret {
 		return fmt.Errorf("invalid secret")
 	}

--- a/inputs/dynamic.go
+++ b/inputs/dynamic.go
@@ -34,8 +34,9 @@ func NewDynamicInput(name string, settings config.DynamicInputConfig) *DynamicIn
 	}
 }
 
-// MetadataUpdate holds the fields for an incoming metadata update via the HTTP API.
-type MetadataUpdate struct {
+// MetadataRequest holds the fields for an incoming metadata update request via the HTTP API.
+// Title is required; Secret is checked when configured for the dynamic input.
+type MetadataRequest struct {
 	SongID   string
 	Artist   string
 	Title    string
@@ -44,7 +45,11 @@ type MetadataUpdate struct {
 }
 
 // UpdateMetadata updates the metadata from an HTTP request.
-func (d *DynamicInput) UpdateMetadata(update *MetadataUpdate) error {
+func (d *DynamicInput) UpdateMetadata(update *MetadataRequest) error {
+	if update == nil {
+		return fmt.Errorf("metadata update is required")
+	}
+
 	if d.settings.Secret != "" && update.Secret != d.settings.Secret {
 		return fmt.Errorf("invalid secret")
 	}

--- a/inputs/url.go
+++ b/inputs/url.go
@@ -82,7 +82,11 @@ func (u *URLInput) poll() {
 	}
 
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		slog.Error("URL must use http or https scheme", "input", u.GetName(), "url", u.settings.URL, "scheme", parsedURL.Scheme) //nolint:gosec // Logging config value for diagnostics
+		slog.Error("URL must use http or https scheme", //nolint:gosec // Logging config value for diagnostics
+			"input", u.GetName(),
+			"url", u.settings.URL,
+			"scheme", parsedURL.Scheme,
+		)
 		return
 	}
 
@@ -114,7 +118,7 @@ func (u *URLInput) poll() {
 			slog.Error("Cannot navigate JSON path", "input", u.GetName(), "path", u.settings.JSONKey)
 			return
 		}
-		content = fmt.Sprintf("%v", contentVal)
+		content = fmt.Sprint(contentVal)
 
 		if u.settings.ExpiryKey != "" {
 			expVal, ok := extractJSONValue(data, u.settings.ExpiryKey)

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -52,7 +52,11 @@ func (h *HTTPOutput) RegisterRoutes(mux *http.ServeMux) {
 			h.handleEndpoint(w, req, endpoint)
 		})
 
-		slog.Info("HTTP endpoint registered", "output", h.GetName(), "path", endpoint.Path, "type", endpoint.ResponseType)
+		slog.Info("HTTP endpoint registered",
+			"output", h.GetName(),
+			"path", endpoint.Path,
+			"type", endpoint.ResponseType,
+		)
 	}
 }
 
@@ -62,7 +66,11 @@ func (h *HTTPOutput) Send(st *core.StructuredText) {
 	h.storeCurrentMetadata(httpMetadata)
 }
 
-func (h *HTTPOutput) handleEndpoint(w http.ResponseWriter, _ *http.Request, endpoint config.HTTPEndpoint) {
+func (h *HTTPOutput) handleEndpoint(
+	w http.ResponseWriter,
+	_ *http.Request,
+	endpoint config.HTTPEndpoint,
+) {
 	metadata := h.getCurrentMetadata()
 	if metadata == nil {
 		http.Error(w, "No metadata available", http.StatusNoContent)
@@ -71,7 +79,11 @@ func (h *HTTPOutput) handleEndpoint(w http.ResponseWriter, _ *http.Request, endp
 
 	responseData, contentType, err := h.generateResponse(metadata, endpoint)
 	if err != nil {
-		slog.Error("Failed to generate HTTP response", "output", h.GetName(), "path", endpoint.Path, "error", err)
+		slog.Error("Failed to generate HTTP response",
+			"output", h.GetName(),
+			"path", endpoint.Path,
+			"error", err,
+		)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -80,10 +92,18 @@ func (h *HTTPOutput) handleEndpoint(w http.ResponseWriter, _ *http.Request, endp
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	if _, err := w.Write(responseData); err != nil {
-		slog.Error("Failed to write HTTP response", "output", h.GetName(), "path", endpoint.Path, "error", err)
+		slog.Error("Failed to write HTTP response",
+			"output", h.GetName(),
+			"path", endpoint.Path,
+			"error", err,
+		)
 	}
 
-	slog.Debug("Served HTTP response", "output", h.GetName(), "path", endpoint.Path, "content_type", contentType)
+	slog.Debug("Served HTTP response",
+		"output", h.GetName(),
+		"path", endpoint.Path,
+		"content_type", contentType,
+	)
 }
 
 func (h *HTTPOutput) generateResponse(
@@ -130,7 +150,10 @@ func (h *HTTPOutput) generateStandardResponse(
 	}
 }
 
-func (h *HTTPOutput) encodeResponse(data any, responseType string) (encoded []byte, contentType string, err error) {
+func (h *HTTPOutput) encodeResponse(
+	data any,
+	responseType string,
+) (encoded []byte, contentType string, err error) {
 	switch strings.ToLower(responseType) {
 	case "xml":
 		if str, ok := data.(string); ok {

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -86,14 +86,18 @@ func (h *HTTPOutput) handleEndpoint(w http.ResponseWriter, _ *http.Request, endp
 	slog.Debug("Served HTTP response", "output", h.GetName(), "path", endpoint.Path, "content_type", contentType)
 }
 
-func (h *HTTPOutput) generateResponse(metadata *utils.UniversalMetadata, endpoint config.HTTPEndpoint) (data []byte, contentType string, err error) {
+func (h *HTTPOutput) generateResponse(
+	metadata *utils.UniversalMetadata, endpoint config.HTTPEndpoint,
+) (data []byte, contentType string, err error) {
 	if endpoint.PayloadMapping != nil {
 		return h.generateCustomResponse(metadata, endpoint)
 	}
 	return h.generateStandardResponse(metadata, endpoint.ResponseType)
 }
 
-func (h *HTTPOutput) generateCustomResponse(metadata *utils.UniversalMetadata, endpoint config.HTTPEndpoint) (data []byte, contentType string, err error) {
+func (h *HTTPOutput) generateCustomResponse(
+	metadata *utils.UniversalMetadata, endpoint config.HTTPEndpoint,
+) (data []byte, contentType string, err error) {
 	mapper := h.endpointMappers[endpoint.Path]
 	if mapper == nil {
 		mapper = utils.NewPayloadMapper(endpoint.PayloadMapping)
@@ -111,7 +115,9 @@ func (h *HTTPOutput) generateCustomResponse(metadata *utils.UniversalMetadata, e
 	return h.encodeResponse(result, endpoint.ResponseType)
 }
 
-func (h *HTTPOutput) generateStandardResponse(metadata *utils.UniversalMetadata, responseType string) (data []byte, contentType string, err error) {
+func (h *HTTPOutput) generateStandardResponse(
+	metadata *utils.UniversalMetadata, responseType string,
+) (data []byte, contentType string, err error) {
 	switch strings.ToLower(responseType) {
 	case "xml":
 		return h.encodeResponse(h.buildXMLString(metadata), responseType)

--- a/outputs/stereotool.go
+++ b/outputs/stereotool.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"zwfm-metadata/config"
 	"zwfm-metadata/core"
@@ -54,7 +55,7 @@ func (i *StereoToolOutput) sendToStereoTool(metadata string) error {
 func (i *StereoToolOutput) updateField(id int, fieldName, metadata string) error {
 	requestURL := fmt.Sprintf("http://%s:%d/json-1/lis{%q:{%q:%q,%q:%q}}",
 		i.settings.Hostname, i.settings.Port,
-		fmt.Sprintf("%d", id), "forced", "1", "new_value", url.QueryEscape(metadata))
+		strconv.Itoa(id), "forced", "1", "new_value", url.QueryEscape(metadata))
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, requestURL, http.NoBody)
 	if err != nil {
@@ -69,7 +70,8 @@ func (i *StereoToolOutput) updateField(id int, fieldName, metadata string) error
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("StereoTool API error for %s: status %d, response: %s", fieldName, resp.StatusCode, string(bodyBytes))
+		return fmt.Errorf("StereoTool API error for %s: status %d, response: %s",
+			fieldName, resp.StatusCode, string(bodyBytes))
 	}
 
 	slog.Debug("Updated StereoTool field", "output", i.GetName(), "field", fieldName, "metadata", metadata)

--- a/outputs/url.go
+++ b/outputs/url.go
@@ -49,7 +49,11 @@ func NewURLOutput(name string, settings config.URLOutputConfig) *URLOutput {
 		return nil
 	}
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		slog.Error("URL must use http or https scheme", "output", name, "url", settings.URL, "scheme", parsedURL.Scheme) //nolint:gosec // Logging config value for diagnostics
+		slog.Error("URL must use http or https scheme", //nolint:gosec // Logging config value for diagnostics
+			"output", name,
+			"url", settings.URL,
+			"scheme", parsedURL.Scheme,
+		)
 		return nil
 	}
 
@@ -85,9 +89,9 @@ func (u *URLOutput) Send(st *core.StructuredText) {
 func (u *URLOutput) sendRequest(payload *utils.UniversalMetadata) {
 	if u.settings.Method == "GET" {
 		u.sendGETRequest(payload)
-	} else {
-		u.sendPOSTRequest(payload)
+		return
 	}
+	u.sendPOSTRequest(payload)
 }
 
 func urlEncodeTemplateData(data map[string]any) map[string]any {
@@ -151,11 +155,19 @@ func (u *URLOutput) sendGETRequest(payload *utils.UniversalMetadata) {
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		slog.Error("GET request failed", "output", u.GetName(), "status", resp.StatusCode, "response", string(bodyBytes)) //nolint:gosec // Logging response for diagnostics
+		slog.Error("GET request failed", //nolint:gosec // Logging response for diagnostics
+			"output", u.GetName(),
+			"status", resp.StatusCode,
+			"response", string(bodyBytes),
+		)
 		return
 	}
 
-	slog.Debug("Successfully sent GET", "output", u.GetName(), "url", finalURL, "status", resp.StatusCode) //nolint:gosec // Logging URL for diagnostics
+	slog.Debug("Successfully sent GET", //nolint:gosec // Logging URL for diagnostics
+		"output", u.GetName(),
+		"url", finalURL,
+		"status", resp.StatusCode,
+	)
 }
 
 func (u *URLOutput) sendPOSTRequest(payload *utils.UniversalMetadata) {
@@ -176,7 +188,9 @@ func (u *URLOutput) sendPOSTRequest(payload *utils.UniversalMetadata) {
 
 	slog.Debug("Sending POST request", "output", u.GetName(), "url", u.settings.URL, "payload", string(jsonData))
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, u.settings.URL, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, u.settings.URL, bytes.NewBuffer(jsonData),
+	)
 	if err != nil {
 		slog.Error("Failed to create POST request", "output", u.GetName(), "error", err)
 		return
@@ -196,9 +210,17 @@ func (u *URLOutput) sendPOSTRequest(payload *utils.UniversalMetadata) {
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		slog.Error("POST request failed", "output", u.GetName(), "status", resp.StatusCode, "response", string(bodyBytes)) //nolint:gosec // Logging response for diagnostics
+		slog.Error("POST request failed", //nolint:gosec // Logging response for diagnostics
+			"output", u.GetName(),
+			"status", resp.StatusCode,
+			"response", string(bodyBytes),
+		)
 		return
 	}
 
-	slog.Debug("Successfully sent POST", "output", u.GetName(), "url", u.settings.URL, "status", resp.StatusCode) //nolint:gosec // Logging URL for diagnostics
+	slog.Debug("Successfully sent POST", //nolint:gosec // Logging URL for diagnostics
+		"output", u.GetName(),
+		"url", u.settings.URL,
+		"status", resp.StatusCode,
+	)
 }

--- a/outputs/url.go
+++ b/outputs/url.go
@@ -39,7 +39,11 @@ func NewURLOutput(name string, settings config.URLOutputConfig) *URLOutput {
 
 	settings.Method = strings.ToUpper(settings.Method)
 	if settings.Method != "GET" && settings.Method != "POST" {
-		slog.Error("Invalid method for URL output", "output", name, "method", settings.Method, "valid_methods", "GET, POST")
+		slog.Error("Invalid method for URL output",
+			"output", name,
+			"method", settings.Method,
+			"valid_methods", "GET, POST",
+		)
 		return nil
 	}
 
@@ -118,7 +122,11 @@ func (u *URLOutput) sendGETRequest(payload *utils.UniversalMetadata) {
 
 		var urlBuffer strings.Builder
 		if err := u.urlTemplate.Execute(&urlBuffer, encodedData); err != nil {
-			slog.Error("Failed to execute URL template", "output", u.GetName(), "template", u.settings.URL, "error", err)
+			slog.Error("Failed to execute URL template",
+				"output", u.GetName(),
+				"template", u.settings.URL,
+				"error", err,
+			)
 			return
 		}
 		requestURL = urlBuffer.String()
@@ -134,7 +142,10 @@ func (u *URLOutput) sendGETRequest(payload *utils.UniversalMetadata) {
 
 	finalURL := parsedURL.String()
 
-	slog.Debug("Sending GET request", "output", u.GetName(), "url", finalURL) //nolint:gosec // Logging URL for diagnostics
+	slog.Debug("Sending GET request", //nolint:gosec // Logging URL for diagnostics
+		"output", u.GetName(),
+		"url", finalURL,
+	)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, finalURL, http.NoBody)
 	if err != nil {
@@ -186,7 +197,11 @@ func (u *URLOutput) sendPOSTRequest(payload *utils.UniversalMetadata) {
 		return
 	}
 
-	slog.Debug("Sending POST request", "output", u.GetName(), "url", u.settings.URL, "payload", string(jsonData))
+	slog.Debug("Sending POST request",
+		"output", u.GetName(),
+		"url", u.settings.URL,
+		"payload", string(jsonData),
+	)
 
 	req, err := http.NewRequestWithContext(
 		context.Background(), http.MethodPost, u.settings.URL, bytes.NewBuffer(jsonData),

--- a/web/server.go
+++ b/web/server.go
@@ -160,7 +160,7 @@ func (s *Server) dynamicInputHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err := dynamicInput.UpdateMetadata(inputs.MetadataUpdate{
+	err := dynamicInput.UpdateMetadata(&inputs.MetadataUpdate{
 		SongID:   songID,
 		Artist:   artist,
 		Title:    title,

--- a/web/server.go
+++ b/web/server.go
@@ -160,7 +160,7 @@ func (s *Server) dynamicInputHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err := dynamicInput.UpdateMetadata(&inputs.MetadataUpdate{
+	err := dynamicInput.UpdateMetadata(&inputs.MetadataRequest{
 		SongID:   songID,
 		Artist:   artist,
 		Title:    title,

--- a/web/server.go
+++ b/web/server.go
@@ -160,7 +160,13 @@ func (s *Server) dynamicInputHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err := dynamicInput.UpdateMetadata(songID, artist, title, duration, secret)
+	err := dynamicInput.UpdateMetadata(inputs.MetadataUpdate{
+		SongID:   songID,
+		Artist:   artist,
+		Title:    title,
+		Duration: duration,
+		Secret:   secret,
+	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return


### PR DESCRIPTION
## Summary

- **MetadataRequest struct**: Replaced 5 positional string parameters on `UpdateMetadata` with a `MetadataRequest` struct to prevent argument-order bugs (renamed from `MetadataUpdate` to clarify it carries request data including auth)
- **Nil guard**: Added nil-pointer check on `UpdateMetadata` for defensive exported API
- **Remove else-after-return**: Refactored `outputs/url.go:sendRequest` to use early return instead of else block
- **strconv conversions**: `fmt.Sprintf("%d", id)` to `strconv.Itoa(id)`, `fmt.Sprintf("%v", val)` to `fmt.Sprint(val)`
- **Consistent line breaking**: Reformatted slog calls and function signatures exceeding ~120 chars across all touched files
- **hugeParam fix**: Pass `MetadataRequest` by pointer to satisfy gocritic lint rule

## Notes on else-after-return

Most locations listed in the issue (e.g., `inputs/dynamic.go:83`, `main.go:129`, `utils/converter.go:82`, `formatters/rds.go:281`, `utils/mapper.go:50`) are standard if/else blocks where neither branch ends with return/break/continue -- the else is structurally required. Only `outputs/url.go:sendRequest` had a genuine else-after-return.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` -- 0 issues
- [x] Manual verification: metadata updates work end-to-end (valid updates, wrong secret, missing title, non-existent input, missing input param all return correct responses)