### PR TITLE
chore: group release notes by category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+        - breaking
+    - title: Features
+      labels:
+        - feature
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary

Adds `.github/release.yml` so GitHub's auto-generated release notes group PRs by category (Breaking Changes, Features, Bug Fixes, Documentation, Dependencies, Other Changes) instead of listing them in commit order.

This means dependabot's `Bump X from Y to Z` PRs land under a "Dependencies" heading at the bottom of the changelog rather than mixing with feature/fix entries.

## Why grouping instead of excluding

Dependency bumps sometimes ship security fixes that downstream consumers should see in the changelog. Hiding them entirely can mask material changes; grouping keeps them visible while keeping the top of the notes focused on hand-authored work.

## Categories

PRs match by label (first match wins, so order matters):

- **Breaking Changes** — `breaking-change`, `breaking`
- **Features** — `feature`, `enhancement`
- **Bug Fixes** — `bug`, `fix`
- **Documentation** — `documentation`, `docs`
- **Dependencies** — `dependencies` (auto-applied by dependabot)
- **Other Changes** — `*` (catch-all)

Most existing labels in this repo will fall into "Other Changes" until we start labeling PRs more deliberately. That's intentional — no behavior change for unlabeled PRs.

## Notes

Companion change to `oszuidwest/zwfm-audiologger#48`. Aligning all four repos to the same release-notes config.