### PR TITLE
ci: pin golangci-lint v2.12.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.4
+          version: v2.12.1
           args: --timeout=5m
       
       - name: Check for dead code


### PR DESCRIPTION
Pins golangci-lint to v2.12.1 in CI/tooling so lint runs are reproducible.

Generated across repositories by Codex.

Verification: not run locally for this repository.