### PR TITLE
chore(release): drop 'on:' quoting in workflow shim

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@
 # `docker pull` line in release notes (GitHub Actions expressions can't slice).
 name: Release
 
-'on':
+on:
   push:
     tags: ['v*']
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Drops the legacy `'on':` (YAML 1.1 truthy quoting) on the release.yml shim. Matches `oszuidwest/.github-templates` PR #17 which standardized on unquoted `on:` across all reusable workflows and templates.

No behavior change.

## Test plan

- [x] `actionlint .github/workflows/release.yml` clean