### PR TITLE
ci: migrate release shim to go-release.yml@v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 ---
-# Thin shim — delegates to oszuidwest/.github-templates go-release.yml@v1.
-# enable-docker: true triggers transitive docker-publish.yml@v1 for releases.
+# Thin shim — delegates to oszuidwest/.github-templates go-release.yml@v2.
+# Docker publishing is composed via a second job that calls
+# docker-publish.yml@v1 directly, gated on the release outputs.
 # The `body` job exists only to compute the v-stripped version for the
 # `docker pull` line in release notes (GitHub Actions expressions can't slice).
 name: Release
@@ -42,7 +43,7 @@ jobs:
 
   release:
     needs: body
-    uses: oszuidwest/.github-templates/.github/workflows/go-release.yml@v1
+    uses: oszuidwest/.github-templates/.github/workflows/go-release.yml@v2
     with:
       project-name: metadata
       ldflags-target: zwfm-metadata/utils
@@ -55,13 +56,21 @@ jobs:
          {"os":"darwin","arch":"amd64"},
          {"os":"darwin","arch":"arm64"}]
       version: ${{ inputs.version }}
-      enable-docker: true
+      release-body: ${{ needs.body.outputs.text }}
+    permissions:
+      contents: write
+
+  docker:
+    needs: release
+    if: needs.release.outputs.is_release == 'true'
+    uses: oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v1
+    with:
+      version: ${{ needs.release.outputs.version }}
       image-labels: |
         org.opencontainers.image.title=ZuidWest FM Metadata
         org.opencontainers.image.description=Metadata middleware for ZuidWest FM
         org.opencontainers.image.vendor=Streekomroep ZuidWest
         org.opencontainers.image.licenses=MIT
-      release-body: ${{ needs.body.outputs.text }}
     permissions:
-      contents: write
+      contents: read
       packages: write


### PR DESCRIPTION
## Summary

Bump release shim from `go-release.yml@v1` to `@v2`. v2 dropped the nested docker job, so this PR splits the shim into three jobs:

- `body` — unchanged, still computes the v-stripped Docker pull command for release notes.
- `release` — calls `go-release.yml@v2` with no Docker-related inputs and `contents: write` only.
- `docker` — new job, calls `docker-publish.yml@v1` directly, gated on `needs.release.outputs.is_release == 'true'`. Carries the OCI labels and `packages: write` previously bundled into the release call.

Edge runs short-circuit at the `if:` so no Docker push happens for them (Phase 0: edge is artifacts-only).

Upstream: oszuidwest/.github-templates#18 (closes oszuidwest/.github-templates#5).

## Test plan

- [ ] After merge, smoke-test via `gh workflow run release.yml -f version=edge` → expect a fresh edge artifact, no Docker push, no parse-time errors.
- [ ] Next real release tag exercises the full Docker publish path; verify GHCR image is published with the same SHA as the binary.