### PR TITLE
chore: trim verbose comments and sync template workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 ---
-# Thin shim — delegates to oszuidwest/.github-templates go-ci.yml@v2.
 name: CI
 
 on:

--- a/.github/workflows/docker-quality.yml
+++ b/.github/workflows/docker-quality.yml
@@ -1,17 +1,5 @@
 ---
-# Docker Quality Workflow Template
-# Source: oszuidwest/.github-templates
-#
-# This workflow lints Dockerfiles, validates YAML, and checks Docker Compose files.
-# Copy to: .github/workflows/docker-quality.yml
-#
-# Required config files:
-#   - .hadolint.yaml (at repo root)
-#
-# Customization:
-#   - DOCKERFILE_PATH: Change if Dockerfile is not at root (e.g., "docker/Dockerfile")
-#   - Adjust YAML lint rules in the inline config as needed
-
+# Requires .hadolint.yaml at the repo root.
 name: Docker Quality
 
 on:
@@ -50,7 +38,7 @@ jobs:
             echo "has_dockerfile=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Configuration in .hadolint.yaml - do NOT duplicate ignore rules here
+      # Ignore rules live in .hadolint.yaml — do not duplicate here.
       - name: Hadolint
         if: steps.check_dockerfile.outputs.has_dockerfile == 'true'
         uses: hadolint/hadolint-action@v3.3.0
@@ -95,7 +83,7 @@ jobs:
             touch .env
           fi
           if ! OUTPUT=$(docker compose config --quiet 2>&1); then
-            # Missing env vars = warning, syntax errors = fail
+            # Missing env vars: warn. Syntax errors: fail.
             if echo "$OUTPUT" | grep -qi "variable is not set"; then
               echo "::warning::Docker Compose validation requires environment variables: $OUTPUT"
             else

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -1,7 +1,4 @@
 ---
-# Docker Security Workflow Template
-# Source: oszuidwest/.github-templates
-
 name: Docker Security
 
 on:
@@ -9,8 +6,7 @@ on:
     branches: [main]
   pull_request:
   schedule:
-    # Weekly on Sunday at 4 AM UTC
-    - cron: '0 4 * * 0'
+    - cron: '0 4 * * 0'  # Weekly Sunday 04:00 UTC
   workflow_dispatch:
   workflow_call:
 
@@ -57,7 +53,7 @@ jobs:
           restore-keys: |
             trivy-db
 
-      # Includes MEDIUM for visibility in Security tab
+      # MEDIUM included so they surface in the Security tab.
       - name: Trivy SARIF Report
         uses: aquasecurity/trivy-action@v0.36.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,5 @@
 ---
-# Thin shim — delegates to oszuidwest/.github-templates go-release.yml@v2.
-# Docker publishing is composed via a second job that calls
-# docker-publish.yml@v2 directly, gated on the release outputs.
-# The `body` job exists only to compute the v-stripped version for the
-# `docker pull` line in release notes (GitHub Actions expressions can't slice).
+# `body` job strips the v-prefix for the docker pull line (GHA expressions can't slice).
 name: Release
 
 on:


### PR DESCRIPTION
## Summary
- Sync `docker-security.yml` + `docker-quality.yml` from trimmed `oszuidwest/.github-templates` workflow-templates.
- Trim verbose shim header comments in `release.yml` + `ci.yml`.
- No functional changes.