### PR TITLE
Expand templates inside array-of-object payload mappings

### DIFF
--- a/utils/mapper.go
+++ b/utils/mapper.go
@@ -40,7 +40,7 @@ func (pm *PayloadMapper) MapPayload(data any) map[string]any {
 	return result
 }
 
-// processMapping walks the mapping tree and applies templates to string values.
+// processMapping walks the mapping tree and applies templates to strings, nested maps, and object slices.
 func (pm *PayloadMapper) processMapping(mapping, result map[string]any, data any) {
 	for key, value := range mapping {
 		switch v := value.(type) {
@@ -69,7 +69,7 @@ func (pm *PayloadMapper) processMapping(mapping, result map[string]any, data any
 	}
 }
 
-// processMappingSlice applies template mapping to each object in a JSON array (other elements pass through).
+// processMappingSlice expands templates inside array-of-object mappings; non-object elements are copied as-is.
 func (pm *PayloadMapper) processMappingSlice(items []any, data any) []any {
 	out := make([]any, len(items))
 	for i, item := range items {

--- a/utils/mapper.go
+++ b/utils/mapper.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"log/slog"
+	"reflect"
 	"strings"
 	"sync"
 	"text/template"
@@ -55,9 +56,33 @@ func (pm *PayloadMapper) processMapping(mapping, result map[string]any, data any
 			pm.processMapping(v, nestedResult, data)
 			result[key] = nestedResult
 		default:
-			result[key] = value
+			if rv := reflect.ValueOf(value); rv.Kind() == reflect.Slice {
+				items := make([]any, rv.Len())
+				for i := range rv.Len() {
+					items[i] = rv.Index(i).Interface()
+				}
+				result[key] = pm.processMappingSlice(items, data)
+			} else {
+				result[key] = value
+			}
 		}
 	}
+}
+
+// processMappingSlice applies template mapping to each object in a JSON array (other elements pass through).
+func (pm *PayloadMapper) processMappingSlice(items []any, data any) []any {
+	out := make([]any, len(items))
+	for i, item := range items {
+		nested, ok := item.(map[string]any)
+		if !ok {
+			out[i] = item
+			continue
+		}
+		nestedResult := make(map[string]any)
+		pm.processMapping(nested, nestedResult, data)
+		out[i] = nestedResult
+	}
+	return out
 }
 
 // processTemplate executes a template string with the provided data.

--- a/utils/mapper_test.go
+++ b/utils/mapper_test.go
@@ -14,6 +14,9 @@ func TestPayloadMapper_ArrayOfMapsExpandsTemplates(t *testing.T) {
 					"performer": "{{.artist}}",
 					"logged_at": "{{.updated_at}}",
 				},
+				map[string]any{
+					"summary": "{{.artist}} - {{.title}}",
+				},
 			},
 		},
 	}
@@ -33,7 +36,7 @@ func TestPayloadMapper_ArrayOfMapsExpandsTemplates(t *testing.T) {
 	if !ok {
 		t.Fatalf("items: got %T", event["items"])
 	}
-	if len(items) != 1 {
+	if len(items) != 2 {
 		t.Fatalf("len(items) = %d", len(items))
 	}
 	row, ok := items[0].(map[string]any)
@@ -48,5 +51,93 @@ func TestPayloadMapper_ArrayOfMapsExpandsTemplates(t *testing.T) {
 	}
 	if row["logged_at"] != "2026-05-14T12:00:00Z" {
 		t.Errorf("logged_at = %q", row["logged_at"])
+	}
+	secondRow, ok := items[1].(map[string]any)
+	if !ok {
+		t.Fatalf("items[1]: got %T", items[1])
+	}
+	if secondRow["summary"] != "Test Artist - Test Song" {
+		t.Errorf("summary = %q", secondRow["summary"])
+	}
+}
+
+func TestPayloadMapper_ArrayPrimitiveValuesPassThrough(t *testing.T) {
+	mapping := map[string]any{
+		"items": []any{
+			"static text",
+			float64(123),
+			true,
+			nil,
+		},
+	}
+	pm := NewPayloadMapper(mapping)
+	got := pm.MapPayload(map[string]any{})
+
+	items, ok := got["items"].([]any)
+	if !ok {
+		t.Fatalf("items: got %T", got["items"])
+	}
+	if len(items) != 4 {
+		t.Fatalf("len(items) = %d", len(items))
+	}
+	if items[0] != "static text" {
+		t.Errorf("items[0] = %q", items[0])
+	}
+	if items[1] != float64(123) {
+		t.Errorf("items[1] = %v", items[1])
+	}
+	if items[2] != true {
+		t.Errorf("items[2] = %v", items[2])
+	}
+	if items[3] != nil {
+		t.Errorf("items[3] = %v", items[3])
+	}
+}
+
+func TestPayloadMapper_MixedArrayMapsAndPrimitives(t *testing.T) {
+	mapping := map[string]any{
+		"items": []any{
+			"before",
+			map[string]any{
+				"track": "{{.title}}",
+			},
+			float64(123),
+			map[string]any{
+				"artist": "{{.artist}}",
+			},
+		},
+	}
+	pm := NewPayloadMapper(mapping)
+	got := pm.MapPayload(map[string]any{
+		"title":  "Test Song",
+		"artist": "Test Artist",
+	})
+
+	items, ok := got["items"].([]any)
+	if !ok {
+		t.Fatalf("items: got %T", got["items"])
+	}
+	if len(items) != 4 {
+		t.Fatalf("len(items) = %d", len(items))
+	}
+	if items[0] != "before" {
+		t.Errorf("items[0] = %q", items[0])
+	}
+	firstMap, ok := items[1].(map[string]any)
+	if !ok {
+		t.Fatalf("items[1]: got %T", items[1])
+	}
+	if firstMap["track"] != "Test Song" {
+		t.Errorf("track = %q", firstMap["track"])
+	}
+	if items[2] != float64(123) {
+		t.Errorf("items[2] = %v", items[2])
+	}
+	secondMap, ok := items[3].(map[string]any)
+	if !ok {
+		t.Fatalf("items[3]: got %T", items[3])
+	}
+	if secondMap["artist"] != "Test Artist" {
+		t.Errorf("artist = %q", secondMap["artist"])
 	}
 }

--- a/utils/mapper_test.go
+++ b/utils/mapper_test.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPayloadMapper_ArrayOfMapsExpandsTemplates(t *testing.T) {
+	mapping := map[string]any{
+		"event": map[string]any{
+			"items": []any{
+				map[string]any{
+					"track":     "{{.title}}",
+					"performer": "{{.artist}}",
+					"logged_at": "{{.updated_at}}",
+				},
+			},
+		},
+	}
+	pm := NewPayloadMapper(mapping)
+	data := map[string]any{
+		"title":      "Test Song",
+		"artist":     "Test Artist",
+		"updated_at": time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
+	}
+	got := pm.MapPayload(data)
+
+	event, ok := got["event"].(map[string]any)
+	if !ok {
+		t.Fatalf("event: got %T", got["event"])
+	}
+	items, ok := event["items"].([]any)
+	if !ok {
+		t.Fatalf("items: got %T", event["items"])
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d", len(items))
+	}
+	row, ok := items[0].(map[string]any)
+	if !ok {
+		t.Fatalf("items[0]: got %T", items[0])
+	}
+	if row["track"] != "Test Song" {
+		t.Errorf("track = %q", row["track"])
+	}
+	if row["performer"] != "Test Artist" {
+		t.Errorf("performer = %q", row["performer"])
+	}
+	if row["logged_at"] != "2026-05-14T12:00:00Z" {
+		t.Errorf("logged_at = %q", row["logged_at"])
+	}
+}


### PR DESCRIPTION
## Problem
In `payloadMapping`, JSON array values were copied through unchanged, so strings like \`{{.title}}\` were sent literally to URL and WebSocket outputs.

## Solution
Detect slice values with `reflect`, walk each element, and when it is a map apply the same string/map template logic as elsewhere.

## Example (placeholders are expanded after this change)
```json
{
  "type": "url",
  "name": "webhook",
  "inputs": ["live"],
  "settings": {
    "url": "https://example.com/hooks/metadata",
    "method": "POST",
    "payloadMapping": {
      "event": {
        "items": [
          {
            "track": "{{.title}}",
            "performer": "{{.artist}}",
            "logged_at": "{{.updated_at}}"
          }
        ]
      }
    }
  }
}
```

## Test
- `TestPayloadMapper_ArrayOfMapsExpandsTemplates`