### PR TITLE
build(docker): migrate image to distroless base

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -21,6 +21,7 @@ ignored:
 
 trustedRegistries:
   - docker.io
+  - cgr.dev
   - ghcr.io
   - gcr.io
   - quay.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     cp config-example.json /runtime/app/config-example.json
 
 # Runtime stage
+# Chainguard static publishes only :latest (rolling) plus immutable digests; pin via digest in CI for reproducibility.
 # hadolint ignore=DL3007
 FROM cgr.dev/chainguard/static:latest
 
@@ -46,7 +47,7 @@ LABEL org.opencontainers.image.source="https://github.com/oszuidwest/zwfm-metada
 LABEL org.opencontainers.image.description="Metadata handling middleware for ZuidWest FM"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Copy runtime files and keep the runtime UID compatible with the old image.
+# Runtime files run as UID/GID 1000 to match volume permissions from prior alpine-based releases.
 COPY --from=builder --chown=1000:1000 /runtime/app /app
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
+# syntax=docker/dockerfile:1
+
 # Build stage
-FROM golang:1.26-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23 AS builder
 
 # Install build dependencies
-RUN apk add --no-cache git ca-certificates tzdata
+RUN apk add --no-cache ca-certificates git
 
-WORKDIR /app
+WORKDIR /src
 
 # Copy go mod files
 COPY go.mod go.sum ./
-RUN go mod download && go mod verify
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download && go mod verify
 
 # Copy source and build
 COPY . .
@@ -23,41 +26,38 @@ ARG COMMIT=unknown
 ARG BUILD_TIME
 
 # Build the binary for the target platform
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-    -ldflags="-w -s -extldflags '-static' -X zwfm-metadata/utils.Version=${VERSION} -X zwfm-metadata/utils.Commit=${COMMIT} -X 'zwfm-metadata/utils.BuildTime=${BUILD_TIME}'" \
-    -a -installsuffix cgo \
-    -o zwfm-metadata .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 \
+    GOOS=${TARGETOS:-linux} \
+    GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+    go build \
+    -trimpath \
+    -buildvcs=false \
+    -ldflags="-s -w -buildid= -X zwfm-metadata/utils.Version=${VERSION} -X zwfm-metadata/utils.Commit=${COMMIT} -X 'zwfm-metadata/utils.BuildTime=${BUILD_TIME}'" \
+    -o /runtime/app/zwfm-metadata . && \
+    cp config-example.json /runtime/app/config-example.json
 
 # Runtime stage
-FROM alpine:3.23
+# hadolint ignore=DL3007
+FROM cgr.dev/chainguard/static:latest
 
 LABEL org.opencontainers.image.source="https://github.com/oszuidwest/zwfm-metadata"
 LABEL org.opencontainers.image.description="Metadata handling middleware for ZuidWest FM"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Upgrade base packages to patch known vulnerabilities + install packages + create user + setup directories
-RUN apk --no-cache upgrade && \
-    apk --no-cache add ca-certificates tzdata wget && \
-    addgroup -g 1000 zwfm && \
-    adduser -D -s /bin/sh -u 1000 -G zwfm zwfm && \
-    mkdir -p /app && \
-    chown zwfm:zwfm /app
+# Copy runtime files and keep the runtime UID compatible with the old image.
+COPY --from=builder --chown=1000:1000 /runtime/app /app
 
 WORKDIR /app
-
-# Copy with correct ownership
-COPY --from=builder --chown=zwfm:zwfm /app/zwfm-metadata ./zwfm-metadata
-COPY --from=builder --chown=zwfm:zwfm /app/config-example.json ./config-example.json
-
-# Switch to non-root user
-USER zwfm
+USER 1000:1000
 
 # Expose port
 EXPOSE 9000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --timeout=3 -O /dev/null http://localhost:9000/ || exit 1
+    CMD ["/app/zwfm-metadata", "-healthcheck", "http://127.0.0.1:9000/"]
 
 # Set default command
-CMD ["./zwfm-metadata", "-config", "config.json"]
+CMD ["/app/zwfm-metadata", "-config", "/app/config.json"]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
-	golang.org/x/net v0.54.0
+	golang.org/x/net v0.55.0
 	golang.org/x/text v0.37.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,7 @@ github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef h1:Ch6Q+AZUxDBCVqd
 github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef/go.mod h1:nXTWP6+gD5+LUJ8krVhhoeHjvHTutPxMYl5SvkcnJNE=
 golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
 golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const healthcheckTimeout = 3 * time.Second
+
+func runHealthcheck(ctx context.Context, targetURL string) error {
+	if targetURL == "" {
+		return errors.New("healthcheck URL is required")
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, healthcheckTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, targetURL, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("create healthcheck request: %w", err)
+	}
+	req.Header.Set("User-Agent", "zwfm-metadata-healthcheck")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute healthcheck request: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // Healthcheck response close errors do not affect readiness.
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("healthcheck returned status %s", resp.Status)
+	}
+
+	return nil
+}

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRunHealthcheck(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{
+			name:   "healthy status",
+			status: http.StatusOK,
+		},
+		{
+			name:   "redirect status",
+			status: http.StatusTemporaryRedirect,
+		},
+		{
+			name:    "bad request status",
+			status:  http.StatusBadRequest,
+			wantErr: true,
+		},
+		{
+			name:    "not found status",
+			status:  http.StatusNotFound,
+			wantErr: true,
+		},
+		{
+			name:    "unhealthy status",
+			status:  http.StatusServiceUnavailable,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			t.Cleanup(server.Close)
+
+			err := runHealthcheck(context.Background(), server.URL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("runHealthcheck() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunHealthcheckRejectsEmptyURL(t *testing.T) {
+	t.Parallel()
+
+	if err := runHealthcheck(context.Background(), ""); err == nil {
+		t.Fatal("runHealthcheck() error = nil, want error")
+	}
+}

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -64,3 +64,15 @@ func TestRunHealthcheckRejectsEmptyURL(t *testing.T) {
 		t.Fatal("runHealthcheck() error = nil, want error")
 	}
 }
+
+func TestRunHealthcheckUnreachableServer(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	if err := runHealthcheck(context.Background(), url); err == nil {
+		t.Fatal("runHealthcheck() error = nil, want error for unreachable server")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -22,8 +22,17 @@ import (
 
 func main() {
 	configFile := flag.String("config", "config.json", "Path to configuration file")
+	healthcheckURL := flag.String("healthcheck", "", "URL to check and exit")
 	showVersion := flag.Bool("version", false, "Show version information")
 	flag.Parse()
+
+	if *healthcheckURL != "" {
+		if err := runHealthcheck(context.Background(), *healthcheckURL); err != nil {
+			fmt.Fprintf(os.Stderr, "healthcheck failed: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
 
 	if *showVersion {
 		fmt.Printf("zwfm-metadata %s (commit: %s, built: %s)\n", utils.Version, utils.Commit, utils.BuildTime)


### PR DESCRIPTION
## Summary
- Switch the runtime stage to the smaller current distroless runtime `cgr.dev/chainguard/static:latest`.
- Copy the stripped static Go binary plus `config-example.json` into the final image and keep runtime UID/GID `1000:1000` for existing bind mounts.
- Add an in-binary `-healthcheck` mode so Docker HEALTHCHECK works without shell/wget in distroless.
- Use `http.NewRequestWithContext` with a timeout context and defer response-body closing per project conventions.
- Add `cgr.dev` to hadolint trusted registries and keep a targeted DL3007 ignore because Chainguard Static publishes its production image as the rolling `:latest` tag.
- Bump `golang.org/x/net` to `v0.55.0` to keep `govulncheck` green after the latest advisory database update.

## Base image selection
- Google Distroless current static line: `gcr.io/distroless/static-debian13:nonroot`.
- Ubuntu 26.04 exists as `ubuntu:26.04`, and Chisel has `ubuntu-26.04` slice definitions, but there is no generic prebuilt chiseled/static Go base comparable to Google/Chainguard.
- Chainguard `static:latest` is intended for standalone static binaries and locally measured smaller than Google `static-debian13` while still including CA certificates and tzdata.
- Platform coverage matches this repo's Docker publish workflow: `linux/amd64,linux/arm64`.

## Local measurements
- `cgr.dev/chainguard/static:latest`: inspect size `635,593` bytes.
- `gcr.io/distroless/static-debian13:nonroot`: inspect size `819,346` bytes.
- `ubuntu:26.04`: inspect size `41,567,720` bytes and includes `/bin/bash`, so it is not distroless.
- Final app image `zwfm-metadata:distroless-local`: inspect size `5,377,221` bytes.

## Verification
- `go test ./...`
- `go vet ./...`
- `golangci-lint run --timeout=5m`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`
- `hadolint --config .hadolint.yaml Dockerfile`
- `docker compose config --quiet`
- `docker build --pull -t zwfm-metadata:distroless-local .`
- `docker buildx build --platform linux/amd64,linux/arm64 --pull --output type=cacheonly .`
- Ran `zwfm-metadata:distroless-local` locally on this Mac with `/tmp/zwfm-metadata-distroless-config.json`; container reports healthy, dashboard responds on `http://127.0.0.1:9000/`, `/api/current.txt` returns `Local Docker test`, and `/api/nowplaying.json` returns the expected JSON metadata.
- Verified `/app/config-example.json` is present in the final image.